### PR TITLE
Use SHA versions for GitHub Actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Editor Config Validation against PR base commit
-      uses: github/super-linter/slim@v5
+      uses: github/super-linter/slim@962a6409c1b303d0e53a9d34ada577a0362f4fae # v5.2.1
       env:
         VALIDATE_ALL_CODEBASE: false
         VALIDATE_EDITORCONFIG: true


### PR DESCRIPTION
Use a defined version of the super-linter